### PR TITLE
Add data volume to MySQL service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     restart: always
     volumes:
       - "./docker/mysql/conf/my.cnf:/etc/mysql/my.cnf:ro"
+      - "mysqldata:/var/lib/mysql"
     environment:
       MYSQL_ROOT_HOST: 172.*.*.*
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
@@ -61,4 +62,5 @@ networks:
     driver: bridge
 
 volumes:
+  mysqldata:
   dragonflydata:


### PR DESCRIPTION
At the moment, the MySQL database is lost when `docker compose down` is executed, while the Redis data and the file system are preserved. This means that if you run `docker compose up` again, the database will no longer exist and your setup will be in a broken state.

Adding a data volume to the MySQL service ensures that the database is never lost unless you explicitly use `docker compose down -v`, which also deletes the volumes.